### PR TITLE
Choose the expansion rule using return type annotations

### DIFF
--- a/src/python/pyqgl2/inline.py
+++ b/src/python/pyqgl2/inline.py
@@ -1882,6 +1882,10 @@ def add_runtime_call_check(call_ptree, func_ptree):
     pyqgl2.ast_util.copy_all_loc(new_call_ast, call_ptree, recurse=True)
     new_call_ast.value.qgl2_checked_call = True
 
+    # mark the call with the return type (if any) of the checked call
+    if hasattr(func_ptree, 'qgl_return'):
+        new_call_ast.value.qgl_return = func_ptree.qgl_return
+
     if tmp_check_tuples:
         checker = make_check_ast_vec(
                 func_ptree.name, call_ptree, tmp_check_tuples)

--- a/src/python/qgl2/basic_sequences/CRMin.py
+++ b/src/python/qgl2/basic_sequences/CRMin.py
@@ -25,7 +25,7 @@ def doPiRabi():
         init(qr)
         Id(qr[0])
         flat_top_gaussian_edge(qr[0], qr[1], riseFall, amp=amp, phase=phase, length=l)
-        Barrier((qr,))
+        Barrier(qr)
         MEAS(qr)
 
     # Sequence 2: X(control), gaussian(l), X(control), measure both
@@ -34,7 +34,7 @@ def doPiRabi():
         X(qr[0])
         flat_top_gaussian_edge(qr[0], qr[1], riseFall, amp=amp, phase=phase, length=l)
         X(qr[0])
-        Barrier((qr,))
+        Barrier(qr)
         MEAS(qr)
 
     # Then do calRepeats calibration sequences
@@ -58,7 +58,7 @@ def doEchoCRLen():
         echoCR(qr[0], qr[1], length=l, phase=phase,
                riseFall=riseFall)
         Id(qr[0])
-        Barrier((qr,))
+        Barrier(qr)
         MEAS(qr)
 
     # Sequence 2
@@ -68,7 +68,7 @@ def doEchoCRLen():
         echoCR(qr[0], qr[1], length=l, phase=phase,
                riseFall=riseFall)
         X(qr[0])
-        Barrier((qr,))
+        Barrier(qr)
         MEAS(qr)
 
     # Then do calRepeats calibration sequences
@@ -93,7 +93,7 @@ def doEchoCRPhase():
                riseFall=riseFall)
         X90(qr[1])
         Id(qr[0])
-        Barrier((qr,))
+        Barrier(qr)
         MEAS(qr)
 
     # Sequence 2
@@ -104,7 +104,7 @@ def doEchoCRPhase():
                riseFall=riseFall)
         X90(qr[1])
         X(qr[0])
-        Barrier((qr,))
+        Barrier(qr)
         MEAS(qr)
 
     # Then do calRepeats calibration sequences

--- a/src/python/qgl2/basic_sequences/RabiMin.py
+++ b/src/python/qgl2/basic_sequences/RabiMin.py
@@ -75,7 +75,7 @@ def doSwap(qr:qreg, delays):
         init(qr)
         X(qr)
         Id(qr[1], length=d)
-        Barrier((qr,))
+        Barrier(qr)
         MEAS(qr)
 
     create_cal_seqs(qr, 2)

--- a/src/python/qgl2/basic_sequences/helpers.py
+++ b/src/python/qgl2/basic_sequences/helpers.py
@@ -35,5 +35,5 @@ def create_cal_seqs(qubits: qreg, numRepeats):
             init(qubits)
             for pulse, qubit in zip(pulseSet, qubits):
                 pulse(qubit)
-            Barrier((qubits,))
+            Barrier(qubits)
             MEAS(qubits)

--- a/src/python/qgl2/qgl1.py
+++ b/src/python/qgl2/qgl1.py
@@ -4,7 +4,7 @@
 # how to handle these functions
 
 # The annotations are defined in here
-from qgl2.qgl2 import qreg, pulse, qgl2stub, qgl2meas, sequence, qreg_list, control
+from qgl2.qgl2 import qreg, pulse, qgl2stub, qgl2meas, qreg_list, control
 
 # Many uses of Id supply a delay. That's the length: an int or float
 # FIXME: Do we need to include that explicitly?
@@ -85,12 +85,12 @@ def flat_top_gaussian_edge(source: qreg, target: qreg, riseFall,
     print('flat_top_gaussian_edge')
 
 @qgl2stub('QGL.PulsePrimitives')
-def echoCR(controlQ: qreg, targetQ: qreg, amp=1, phase=0, length=200e-9, riseFall=20e-9, lastPi=True) -> sequence:
+def echoCR(controlQ: qreg, targetQ: qreg, amp=1, phase=0, length=200e-9, riseFall=20e-9, lastPi=True) -> pulse:
     print('echoCR')
 
 
 @qgl2stub('QGL.PulsePrimitives')
-def CNOT(controlQ: qreg, targetQ: qreg, **kwargs) -> sequence:
+def CNOT(controlQ: qreg, targetQ: qreg, **kwargs) -> pulse:
     print('CNOT')
 
 # FIXME: QGL2 can't handle *args
@@ -151,7 +151,7 @@ def Sync() -> control:
 
 # This function is QGL1 but only for use by QGL2
 @qgl2stub('qgl2.qgl1control')
-def Barrier(chanlist: qreg_list) -> control:
+def Barrier(chanlist: qreg) -> control:
     # chanlist is list of channels that are waiting here
     print('Barrier(%s)' % (chanlist))
 

--- a/src/python/qgl2/qgl1_util.py
+++ b/src/python/qgl2/qgl1_util.py
@@ -6,8 +6,8 @@ from QGL.ChannelLibrary import EdgeFactory
 from QGL.ControlFlow import Sync, Wait
 from QGL.PulsePrimitives import flat_top_gaussian
 
-def init_real(q):
-    return Wait(q)
+def init_real(*args):
+    return Wait(args)
 
 def flat_top_gaussian_edge_impl(
         source, target, riseFall, length, amp, phase=0):

--- a/src/python/qgl2/qgl1control.py
+++ b/src/python/qgl2/qgl1control.py
@@ -12,7 +12,7 @@ from QGL.ControlFlow import ControlInstruction
 # or a Sync then a Wait if the block is of indeterminate length.
 class Barrier(ControlInstruction):
     # chanlist is a list of Channel instances
-    def __init__(self, chanlist):
+    def __init__(self, *chanlist):
         super(Barrier, self).__init__("BARRIER")
         # Consider adding a start/end marker,
         # to help line up barriers across sequences.

--- a/src/python/qgl2/util.py
+++ b/src/python/qgl2/util.py
@@ -1,6 +1,6 @@
 # Copyright 2016 by Raytheon BBN Technologies Corp.  All Rights Reserved.
 
-from qgl2.qgl2 import qreg, pulse, qgl2decl, qgl2stub
+from qgl2.qgl2 import qreg, pulse, control, qgl2decl, qgl2stub
 
 # init will demarcate the beginning of a list of
 # experiments. QGL1 compiler injects WAITs in beginning of
@@ -22,7 +22,7 @@ from qgl2.qgl2 import qreg, pulse, qgl2decl, qgl2stub
 # error checking, etc, then make this a qgl2decl instead.
 
 @qgl2stub("qgl2.qgl1_util", "init_real")
-def init(q: qreg) -> pulse:
+def init(q: qreg) -> control:
     """
     Wait()
     Annotated as returning a pulse for backwards compatibility.

--- a/test/code/edge.py
+++ b/test/code/edge.py
@@ -44,8 +44,6 @@ def edgeTest4():
 
 @qgl2decl
 def cnotcrTest():
-    q1 = QRegister('q1')
-    q2 = QRegister('q2')
-    for q in [q1, q2]:
-        init(q)
-    CNOT(q1, q2)
+    qr = QRegister('q1', 'q2')
+    init(qr)
+    CNOT(qr[0], qr[1])

--- a/test/code/multi.py
+++ b/test/code/multi.py
@@ -12,7 +12,7 @@ def multiQbitTest2():
 
     Id(qs)
     X(qs)
-    Barrier((qs,))
+    Barrier(qs)
     MEAS(qs)
 
 @qgl2decl
@@ -36,7 +36,7 @@ def anotherMulti():
     qs = QRegister(2)
     Id(qs)
     X(qs)
-    Barrier((qs,))
+    Barrier(qs)
     MEAS(qs)
     Y(qs)
 
@@ -46,9 +46,9 @@ def anotherMulti2():
     qsub = QRegister(qs[0], qs[1])
     Id(qsub)
     X(qs[0:2]) # equivalent to calling with qsub argument
-    Barrier((qs,))
+    Barrier(qs)
     MEAS(qsub)
-    Barrier((qs,))
+    Barrier(qs)
     Y(qs[0])
     Y(qs[2])
 
@@ -59,8 +59,8 @@ def anotherMulti3():
     qsub = QRegister(qs[0:2])
     Id(qsub)
     X(qsub)
-    Barrier((qs,))
+    Barrier(qs)
     MEAS(qsub)
-    Barrier((qs,))
+    Barrier(qs)
     Y(qs[0])
     Y(qs[2])

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -302,9 +302,9 @@ def get_cal_seqs_1qubit(qubit, calRepeats=2):
     for pulse in [Id, X]:
         for _ in range(calRepeats):
             calSeq += [
-                qwait(qubit),
+                qwait((qubit,)),
                 pulse(qubit),
-                Barrier((qubit,)),
+                Barrier(qubit),
                 MEAS(qubit)
             ]
     return calSeq
@@ -318,11 +318,10 @@ def get_cal_seqs_2qubits(q1, q2, calRepeats=2):
     for pulseSet in [(Id, Id), (Id, X), (X, Id), (X, X)]:
         for _ in range(calRepeats):
             calseq += [
-                qwait(q1),
-                qwait(q2),
+                qwait((q1, q2)),
                 pulseSet[0](q1),
                 pulseSet[1](q2),
-                Barrier((q1, q2)),
+                Barrier(q1, q2),
                 MEAS(q1),
                 MEAS(q2)
             ]

--- a/test/test_basic_mins.py
+++ b/test/test_basic_mins.py
@@ -27,11 +27,11 @@ class TestAllXY(unittest.TestCase):
         # Expect a single sequence 4 * 2 * 21 pulses long
         # Expect it to start like this:
         expectedseq += [
-            qwait(q1),
+            qwait((q1,)),
             Id(q1),
             Id(q1),
             MEAS(q1),
-            qwait(q1),
+            qwait((q1,)),
             Id(q1),
             Id(q1),
             MEAS(q1)
@@ -64,11 +64,11 @@ class TestAllXY(unittest.TestCase):
         # Expect a single sequence 4 * 2 * 21 pulses long
         # Expect it to start like this:
         expectedseq += [
-            qwait(q1),
+            qwait((q1,)),
             Id(q1),
             Id(q1),
             MEAS(q1),
-            qwait(q1),
+            qwait((q1,)),
             Id(q1),
             Id(q1),
             MEAS(q1)
@@ -91,11 +91,11 @@ class TestAllXY(unittest.TestCase):
         # Expect a single sequence 4 * 2 * 21 pulses long
         # Expect it to start like this:
         expectedseq += [
-            qwait(q1),
+            qwait((q1,)),
             Id(q1),
             Id(q1),
             MEAS(q1),
-            qwait(q1),
+            qwait((q1,)),
             Id(q1),
             Id(q1),
             MEAS(q1)
@@ -131,23 +131,21 @@ class TestCR(unittest.TestCase):
         # Seq1
         for l in lengths:
             expected_seq += [
-                qwait(controlQ),
-                qwait(targetQ),
+                qwait((controlQ, targetQ)),
                 Id(controlQ),
                 flat_top_gaussian(edge, riseFall, length=l, amp=amp, phase=phase),
-                Barrier((controlQ, targetQ)),
+                Barrier(controlQ, targetQ),
                 MEAS(controlQ),
                 MEAS(targetQ)
             ]
         # Seq2
         for l in lengths:
             expected_seq += [
-                qwait(controlQ),
-                qwait(targetQ),
+                qwait((controlQ, targetQ)),
                 X(controlQ),
                 flat_top_gaussian(edge, riseFall, length=l, amp=amp, phase=phase),
                 X(controlQ),
-                Barrier((controlQ, targetQ)),
+                Barrier(controlQ, targetQ),
                 MEAS(controlQ),
                 MEAS(targetQ)
             ]
@@ -179,26 +177,24 @@ class TestCR(unittest.TestCase):
         # Seq1
         for l in lengths:
             expected_seq += [
-                qwait(controlQ),
-                qwait(targetQ),
+                qwait((controlQ, targetQ)),
                 Id(controlQ),
                 echoCR(controlQ, targetQ, length=l, phase=phase,
                        riseFall=riseFall),
                 Id(controlQ),
-                Barrier((controlQ, targetQ)),
+                Barrier(controlQ, targetQ),
                 MEAS(controlQ),
                 MEAS(targetQ)
             ]
         # Seq2
         for l in lengths:
             expected_seq += [
-                qwait(controlQ),
-                qwait(targetQ),
+                qwait((controlQ, targetQ)),
                 X(controlQ),
                 echoCR(controlQ, targetQ, length=l, phase=phase,
                        riseFall=riseFall),
                 X(controlQ),
-                Barrier((controlQ, targetQ)),
+                Barrier(controlQ, targetQ),
                 MEAS(controlQ),
                 MEAS(targetQ)
             ]
@@ -229,14 +225,13 @@ class TestCR(unittest.TestCase):
         # Seq1
         for p in phases:
             expected_seq += [
-                qwait(controlQ),
-                qwait(targetQ),
+                qwait((controlQ, targetQ)),
                 Id(controlQ),
                 echoCR(controlQ, targetQ, length=length, phase=p,
                        riseFall=riseFall),
                 X90(targetQ),
                 Id(controlQ),
-                Barrier((controlQ, targetQ)),
+                Barrier(controlQ, targetQ),
                 MEAS(controlQ),
                 MEAS(targetQ)
             ]
@@ -244,14 +239,13 @@ class TestCR(unittest.TestCase):
         # Seq2
         for p in phases:
             expected_seq += [
-                qwait(controlQ),
-                qwait(targetQ),
+                qwait((controlQ, targetQ)),
                 X(controlQ),
                 echoCR(controlQ, targetQ, length=length, phase=p,
                        riseFall=riseFall),
                 X90(targetQ),
                 X(controlQ),
-                Barrier((controlQ, targetQ)),
+                Barrier(controlQ, targetQ),
                 MEAS(controlQ),
                 MEAS(targetQ)
             ]
@@ -283,7 +277,7 @@ class TestDecoupling(unittest.TestCase):
         expectedseq = []
         for k in range(len(pulseSpacings)):
             expectedseq += [
-                qwait(q),
+                qwait((q,)),
                 X90(q),
                 Id(q, pulseSpacings[k]),
                 Y(q),
@@ -328,7 +322,7 @@ class TestDecoupling(unittest.TestCase):
         expectedseq = []
         for rep in numPulses:
             expectedseq += [
-                qwait(q),
+                qwait((q,)),
                 X90(q)
             ]
             expectedseq += addt180t(q, pulseSpacing, rep)
@@ -364,7 +358,7 @@ class TestFlipFlop(unittest.TestCase):
             ffs = []
             for rep in range(maxNumFFs):
                 ffs += [
-                    qwait(qubit),
+                    qwait((qubit,)),
                     X90(qubit, dragScaling=dragParam)
                 ]
                 for _ in range(rep):
@@ -381,13 +375,13 @@ class TestFlipFlop(unittest.TestCase):
         expectedseq = []
         for dragParam in dragParamSweep:
             expectedseq += [
-                qwait(qubit),
+                qwait((qubit,)),
                 Id(qubit),
                 MEAS(qubit)
             ]
             expectedseq += addFFSeqs(dragParam, maxNumFFs, qubit)
         expectedseq += [
-            qwait(qubit),
+            qwait((qubit,)),
             X(qubit),
             MEAS(qubit)
         ]
@@ -413,7 +407,7 @@ class TestRabiMin(unittest.TestCase):
         expectedseq = []
         for amp in amps:
             expectedseq += [
-                qwait(q1),
+                qwait((q1,)),
                 Utheta(q1, amp=amp, phase=phase),
                 MEAS(q1)
             ]
@@ -441,7 +435,7 @@ class TestRabiMin(unittest.TestCase):
         expectedseq = []
         for l in widths:
             expectedseq += [
-                qwait(q1),
+                qwait((q1,)),
                 Utheta(q1, length=l, amp=1, phase=0, shapeFun=local_tanh),
                 MEAS(q1)
             ]
@@ -463,8 +457,7 @@ class TestRabiMin(unittest.TestCase):
         expectedseq = []
         for amp in amps:
             expectedseq += [
-                qwait(q1),
-                qwait(q2),
+                qwait((q1,q2)),
                 X(q2),
                 Utheta(q1, amp=amp, phase=0),
                 X(q2),
@@ -483,10 +476,10 @@ class TestRabiMin(unittest.TestCase):
         seqs = testable_sequence(seqs)
 
         expectedseq = [
-            qwait(q1),
+            qwait((q1,)),
             Id(q1),
             MEAS(q1),
-            qwait(q1),
+            qwait((q1,)),
             X(q1),
             MEAS(q1)
         ]
@@ -503,7 +496,7 @@ class TestRabiMin(unittest.TestCase):
         seqs = testable_sequence(seqs)
 
         expectedseq = [
-            qwait(q1),
+            qwait((q1,)),
             X(q1),
             MEAS(q1)
         ]
@@ -522,8 +515,7 @@ class TestRabiMin(unittest.TestCase):
 
         for a in amps:
             expectedseq += [
-                qwait(q1),
-                qwait(q2),
+                qwait((q1,q2)),
                 Utheta(q1, amp=a, phase=p),
                 Utheta(q2, amp=a, phase=p),
                 MEAS(q1),
@@ -553,12 +545,11 @@ class TestRabiMin(unittest.TestCase):
         expectedseq = []
         for d in delays:
             expectedseq += [
-                qwait(q),
-                qwait(mq),
+                qwait((q, mq)),
                 X(q),
                 X(mq),
                 Id(mq, length=d),
-                Barrier((q, mq)),
+                Barrier(q, mq),
                 MEAS(q),
                 MEAS(mq)
             ]
@@ -592,7 +583,7 @@ class TestSPAM(unittest.TestCase):
             thisseq = []
             for rep in range(maxSpamBlocks):
                 thisseq += [
-                    qwait(q),
+                    qwait((q,)),
                     Y90(q)
                 ]
                 innerseq = []
@@ -612,13 +603,13 @@ class TestSPAM(unittest.TestCase):
 
         for angle in angleSweep:
             expectedseq += [
-                qwait(q),
+                qwait((q,)),
                 Id(q),
                 MEAS(q)
             ]
             expectedseq += spam_seqs(angle, q, maxSpamBlocks)
         expectedseq += [
-            qwait(q),
+            qwait((q,)),
             X(q),
             MEAS(q)
         ]
@@ -641,7 +632,7 @@ class TestT1T2(unittest.TestCase):
         expectedseq = []
         for d in delays:
             expectedseq += [
-                qwait(q),
+                qwait((q,)),
                 X(q),
                 Id(q, d),
                 MEAS(q)
@@ -674,7 +665,7 @@ class TestT1T2(unittest.TestCase):
         # Create the basic Ramsey sequence
         for d,phase in zip(delays, phases):
             expectedseq += [
-                qwait(q),
+                qwait((q,)),
                 X90(q),
                 Id(q, d),
                 U90(q, phase=phase),

--- a/test/test_edge.py
+++ b/test/test_edge.py
@@ -21,8 +21,7 @@ class TestEdge(unittest.TestCase):
         q1 = QubitFactory('q1')
         q2 = QubitFactory('q2')
         expected = [
-            qwait(q1),
-            qwait(q2),
+            qwait((q1, q2)),
             X(q1),
             X(q2),
             echoCR(q1, q2)
@@ -40,8 +39,8 @@ class TestEdge(unittest.TestCase):
         q1 = QubitFactory('q1')
         q2 = QubitFactory('q2')
         expected = [
-            qwait(q1),
-            qwait(q2),
+            qwait((q1,)),
+            qwait((q2,)),
             echoCR(q1, q2),
             X(q2),
             Y(q2),
@@ -63,8 +62,8 @@ class TestEdge(unittest.TestCase):
         q2 = QubitFactory('q2')
 
         expected = [
-            qwait(q1),
-            qwait(q2),
+            qwait((q1,)),
+            qwait((q2,)),
             echoCR(q1, q2),
             echoCR(q2, q1),
             echoCR(q1, q2),
@@ -86,8 +85,7 @@ class TestEdge(unittest.TestCase):
         q1 = QubitFactory('q1')
         q2 = QubitFactory('q2')
         expected = [
-            qwait(q1),
-            qwait(q2),
+            qwait((q1,q2)),
             CNOT(q1, q2)
         ]
         expected = testable_sequence(expected)

--- a/test/test_multi.py
+++ b/test/test_multi.py
@@ -25,7 +25,7 @@ class TestMulti(unittest.TestCase):
             Id(q2),
             X(q1),
             X(q2),
-            Barrier((q1, q2)),
+            Barrier(q1, q2),
             MEAS(q1),
             MEAS(q2)
         ]
@@ -58,7 +58,7 @@ class TestMulti(unittest.TestCase):
             Id(q2),
             X(q1),
             X(q2),
-            Barrier((q1, q2)),
+            Barrier(q1, q2),
             MEAS(q1),
             MEAS(q2),
             Y(q1),
@@ -84,10 +84,10 @@ class TestMulti(unittest.TestCase):
             Id(q2),
             X(q1),
             X(q2),
-            Barrier((q1, q2, q3)),
+            Barrier(q1, q2, q3),
             MEAS(q1),
             MEAS(q2),
-            Barrier((q1, q2, q3)),
+            Barrier(q1, q2, q3),
             Y(q1),
             Y(q3)
         ]


### PR DESCRIPTION
So that if we have a stub declared to return `pulse`:
```python
@qgl2stub
def foo(q: qreg) -> pulse:
    pass
```
then calling that stub will expand to a list of a calls on each element of the register.

However, if a stub is declared to return `control`:
```python
@qgl2stub
def bar(q: qreg) -> control:
    pass
```
then calling that stub will expand to a splatted version of the arguments.

As a next step, I wanted `init` (which is a qgl2stub) to accept a varargs list of `QRegister`s. However, the inliner cannot handle this, yet.
